### PR TITLE
update boost groupid and versions based on latest boost updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>mp22-bom</artifactId>
-				<version>0.1.3-SNAPSHOT</version>
+				<version>0.2</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -52,31 +52,31 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>cdi</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jsonb</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>mpRestClient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>mpConfig</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>mpHealth</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>bean-validation</artifactId>
 		</dependency>
 
@@ -112,9 +112,9 @@
                 <version>3.0-M3-SNAPSHOT</version>
 			</plugin>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
-				<version>0.1.3-SNAPSHOT</version>
+				<version>0.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -180,23 +180,8 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>wlp</id>
-			<activation>
-				<property>
-					<name>boostRuntime</name>
-					<value>wlp</value>
-				</property>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>boost.runtimes</groupId>
-					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>
@@ -210,7 +195,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -65,15 +65,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.microshed.boost.boosters</groupId>
-			<artifactId>mpRestClient</artifactId>
+			<artifactId>mp-rest-client</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.microshed.boost.boosters</groupId>
-			<artifactId>mpConfig</artifactId>
+			<artifactId>mp-config</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.microshed.boost.boosters</groupId>
-			<artifactId>mpHealth</artifactId>
+			<artifactId>mp-health</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.microshed.boost.boosters</groupId>


### PR DESCRIPTION
updated the pom to use the new boost groupids and also eliminated the wlp profile stanza (since it was agreed it was not needed for this demo)